### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN apt-get update && \
+    apt-get install -y ffmpeg && \
+    pip install --no-cache-dir -r requirements.txt && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+CMD ["python", "demo_cli.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  voice-cloning:
+    build: .
+    volumes:
+      - .:/app
+    command: python demo_cli.py
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
## Summary
- add Dockerfile for containerized environment
- add docker-compose.yml to simplify running the demo

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848b5d489b48324aca139e630fb142b